### PR TITLE
SmallObjectDetectionList

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ If you know of a paper that addresses an Vision-based Small Object Detection pro
 ## 1.1. Multiple feature maps fusion <a name="1.1"></a>  
 - MDSSD: Multi-scale Deconvolutional Single Shot Detector for Small Objects, arXiv 2018, [[paper]](https://arxiv.org/pdf/1805.07009.pdf)   
 - MR-CNN: A Multi-Scale Region-Based Convolutional Neural Network for Small Traffic Sign Recognition, IEEE Acess 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8701699)
-- Improving Tiny Vehicle Detection in Complex Scenes, IEEE ICME 2018, [[paper]](https://ieeexplore.ieee.org/application/enterprise/entconfirmation.jsp?arnumber=8486507&icp=false) NoPDF
+- Improving Tiny Vehicle Detection in Complex Scenes, IEEE ICME 2018, [[paper]](https://www.computer.org/csdl/proceedings-article/icme/2018/08486507/14jQfPe2Vca) NoPDF
 - Small Object Detection with Multiscale Features, Int. J. Digit. Multimedia Broadcast 2018, [[paper]](https://pdfs.semanticscholar.org/942e/386250587fc789d807093cc56f0a95f9798c.pdf?_ga=2.175036386.1996274586.1568206454-1908503646.1568206454)
-- A detection method for low-pixel ratio object, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6653-6) NoPDF
-- Research on Small Size Object Detection in Complex Background, CAC 2018, [[paper]](https://www.semanticscholar.org/paper/Research-on-Small-Size-Object-Detection-in-Complex-Du-Qu/46b1f5b937e114be94d4359c7779372e09ddd122) NoPDF
-- Small Object Detection Using Deep Feature Pyramid Networks, PCM 2018, [[paper]](https://link.springer.com/chapter/10.1007/978-3-030-00764-5_51) NoPDF 
+- A detection method for low-pixel ratio object, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/content/pdf/10.1007%2Fs11042-018-6653-6.pdf)
+- Research on Small Size Object Detection in Complex Background, CAC 2018, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8623078)
+- Small Object Detection Using Deep Feature Pyramid Networks, PCM 2018, [[paper]](https://link.springer.com/chapter/10.1007/978-3-030-00764-5_51)
 - Multiple receptive fields and small-object-focusing weaklysupervised segmentation network for fast object detection, arXiv 2019, [[paper]](https://arxiv.org/ftp/arxiv/papers/1904/1904.12619.pdf)
 - A Block Object Detection Method Based on Feature Fusion Networks for Autonomous Vehicles, Complexity 2019, [[paper]](http://downloads.hindawi.com/journals/complexity/2019/4042624.pdf)
 - Small Object Sensitive Segmentation of Urban Street Scene with Spatial Adjacency Between Object Classes, IEEE TIP 2019, [[paper]](https://cse.sc.edu/~songwang/document/tip19b.pdf)

--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@ List of the Papers Addressing Vision-based Small Object Detection, links to more
 
 ``````````````````````````````
 ### To be finished, need to change to ours when the survey is done
-K. Oksuz, B. C. Cam, S. Kalkan, E. Akbas, "Imbalance Problems in Object Detection: A Review", (under review), 2019.[[preprint]](https://arxiv.org/abs/1909.00169)
+Author, "Title", 2019.[[preprint]](link)
 
 BibTeX entry:
 ```
-@ARTICLE{imbalance,
-       author = {Kemal Oksuz and Baris Can Cam and Sinan Kalkan and Emre Akbas},
-        title = "{Imbalance Problems in Object Detection: A Review}",
-      journal = {arXiv e-prints},
+@ARTICLE{,
+       author = {},
+        title = "{}",
+      journal = {},
          year = "2019",
-        month = "Aug",
-        pages = {arXiv:1909.00169},
-          ee  = {https://arxiv.org/abs/1909.00169},
-       eprint = {1909.00169} 
+        month = "",
+        pages = {},
+          ee  = {},
+       eprint = {} 
 }
 ```
 
@@ -47,16 +47,16 @@ If you know of a paper that addresses an Vision-based Small Object Detection pro
 ## 1.1. Multiple feature maps fusion <a name="1.1"></a>  
 - MDSSD: Multi-scale Deconvolutional Single Shot Detector for Small Objects, arXiv 2018, [[paper]](https://arxiv.org/pdf/1805.07009.pdf)   
 - MR-CNN: A Multi-Scale Region-Based Convolutional Neural Network for Small Traffic Sign Recognition, IEEE Acess 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8701699)
-- Improving Tiny Vehicle Detection in Complex Scenes, IEEE ICME 2018, [[paper]](https://www.computer.org/csdl/proceedings-article/icme/2018/08486507/14jQfPe2Vca) NoPDF
+- Improving Tiny Vehicle Detection in Complex Scenes, IEEE ICME 2018, [[paper]](https://www.computer.org/csdl/proceedings-article/icme/2018/08486507/14jQfPe2Vca) 
 - Small Object Detection with Multiscale Features, Int. J. Digit. Multimedia Broadcast 2018, [[paper]](https://pdfs.semanticscholar.org/942e/386250587fc789d807093cc56f0a95f9798c.pdf?_ga=2.175036386.1996274586.1568206454-1908503646.1568206454)
-- A detection method for low-pixel ratio object, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/content/pdf/10.1007%2Fs11042-018-6653-6.pdf)
+- A detection method for low-pixel ratio object, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/content/pdf/10.1007%2Fs11042-018-6653-6.pdf) 
 - Research on Small Size Object Detection in Complex Background, CAC 2018, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8623078)
-- Small Object Detection Using Deep Feature Pyramid Networks, PCM 2018, [[paper]](https://link.springer.com/chapter/10.1007/978-3-030-00764-5_51)
+- Small Object Detection Using Deep Feature Pyramid Networks, PCM 2018, [[paper]](https://link.springer.com/chapter/10.1007/978-3-030-00764-5_51) 
 - Multiple receptive fields and small-object-focusing weaklysupervised segmentation network for fast object detection, arXiv 2019, [[paper]](https://arxiv.org/ftp/arxiv/papers/1904/1904.12619.pdf)
 - A Block Object Detection Method Based on Feature Fusion Networks for Autonomous Vehicles, Complexity 2019, [[paper]](http://downloads.hindawi.com/journals/complexity/2019/4042624.pdf)
 - Small Object Sensitive Segmentation of Urban Street Scene with Spatial Adjacency Between Object Classes, IEEE TIP 2019, [[paper]](https://cse.sc.edu/~songwang/document/tip19b.pdf)
 ## 1.2. Connection method of different feature maps <a name="1.2"></a>  
-- Detecting Small Objects Using a Channel-Aware Deconvolutional Network, IEEE TCSVT 2019, [[paper]](https://ieeexplore.ieee.org/document/8669953) NoPDF
+- Detecting Small Objects Using a Channel-Aware Deconvolutional Network, IEEE TCSVT 2019, [[paper]](https://ieeexplore.ieee.org/document/8669953) 
 - A unified multi-scale deep convolutional neural network for fast object detection, ECCV 2016, [[paper]](http://www.cvlibs.net/projects/autonomous_vision_survey/literature/Cai2016ECCV.pdf)
 
 # 2. Contextual Information <a name="2"></a>
@@ -72,10 +72,10 @@ If you know of a paper that addresses an Vision-based Small Object Detection pro
 - SINet: A ScaleInsensitive Convolutional Neural Network for Fast Vehicle Detection, IEEE ITS 2019, [[paper]](https://arxiv.org/pdf/1804.00433.pdf)
 - Robust Obstacle Detection and Recognition for Driver Assistance Systems, IEEE ITS 2019, [[paper]](https://www.researchgate.net/profile/Jiaxu_Leng2/publication/332438373_Robust_Obstacle_Detection_and_Recognition_for_Driver_Assistance_Systems/links/5cbeb092a6fdcc1d49a87438/Robust-Obstacle-Detection-and-Recognition-for-Driver-Assistance-Systems.pdf)
 -  Object Detection in Aerial Images Using Feature Fusion Deep Networks, IEEE Acess 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8661761)
-- Small Object Detection in Unmanned Aerial Vehicle Images Using Feature Fusion and Scaling-Based Single Shot Detector with Spatial Context Analysis, IEEE TCSVT 2019, [[paper]](https://ieeexplore.ieee.org/abstract/document/8672115) NoPDF
+- Small Object Detection in Unmanned Aerial Vehicle Images Using Feature Fusion and Scaling-Based Single Shot Detector with Spatial Context Analysis, IEEE TCSVT 2019, [[paper]](https://ieeexplore.ieee.org/abstract/document/8672115) 
 
 # 3. Super-Resolution <a name="3"></a>
-- JCS-Net: Joint Classification and SuperResolution Network for Small-scale Pedestrian Detection in Surveillance Images, IEEE TIFS 2019, [[paper]](https://ieeexplore.ieee.org/abstract/document/8714071) NoPDF
+- JCS-Net: Joint Classification and SuperResolution Network for Small-scale Pedestrian Detection in Surveillance Images, IEEE TIFS 2019, [[paper]](https://ieeexplore.ieee.org/abstract/document/8714071) 
 - Accurate image superresolution using very deep convolutional networks, CVPR 2016, [[paper]](https://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Kim_Accurate_Image_Super-Resolution_CVPR_2016_paper.pdf)
 - Finding tiny faces in the wild with generative adversarial network, CVPR 2018, [[paper]](http://openaccess.thecvf.com/content_cvpr_2018/papers/Bai_Finding_Tiny_Faces_CVPR_2018_paper.pdf)
 - Multi-branch fully convolutional network for face detection, arXiv 2017, [[paper]](https://arxiv.org/pdf/1707.06330.pdf)
@@ -90,24 +90,24 @@ If you know of a paper that addresses an Vision-based Small Object Detection pro
 - Improving Small Object Proposals for Company Logo Detection, ICMR 2017, [[paper]](https://arxiv.org/pdf/1704.08881.pdf)
 - Augmentation for small object detection, arXiv 2019, [[paper]](https://arxiv.org/pdf/1902.07296)
 - Detecting Small Signs from Large Images, IEEE IRI 2017, [[paper]](https://arxiv.org/pdf/1706.08574.pdf)
-- Cascade Mask Generation Framework for Fast Small Object Detection, IEEE ICME 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8486561) NoPDF
-- Cascaded CNN Method for Far Object Detection in Outdoor Surveillance, IEEE SITIS 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8706233) NoPDF
+- Cascade Mask Generation Framework for Fast Small Object Detection, IEEE ICME 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8486561) 
+- Cascaded CNN Method for Far Object Detection in Outdoor Surveillance, IEEE SITIS 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8706233) 
 - SSD-MSN: An Improved Multi-scale Object Detection Network Based on SSD, IEEE Access 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8736726)
 
 # 5. Others <a name="5"></a>
 
 ## 5.1. Traffic road object detection <a name="5.1"></a> 
 - Knowledge-based recurrent attentive neural network for small object detection, arXiv 2018, [[paper]](https://arxiv.org/pdf/1803.05263.pdf)
-- Efficient convNets for fast traffic sign recognition, IET ITS 2019, [[paper]](https://digital-library.theiet.org/content/journals/10.1049/iet-its.2018.5489) NoPDF
-- Real-time small traffic sign detection with revised faster-RCNN, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6428-0) NoPDF
+- Efficient convNets for fast traffic sign recognition, IET ITS 2019, [[paper]](https://digital-library.theiet.org/content/journals/10.1049/iet-its.2018.5489) 
+- Real-time small traffic sign detection with revised faster-RCNN, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6428-0) 
 - Small-scale Pedestrian Detection Based on Topological Line Localization and Temporal Feature Aggregation, ECCV 2018, [[paper]](http://openaccess.thecvf.com/content_ECCV_2018/papers/Tao_Song_Small-scale_Pedestrian_Detection_ECCV_2018_paper.pdf)
 - An Efficient Color Space for Deep-Learning Based Traffic Light Recognition, J Adv Transport 2018, [[paper]](http://downloads.hindawi.com/journals/jat/2018/2365414.pdf)
 - CFENet: An Accurate and Efficient Single-Shot Object Detector for Autonomous Driving, arXiv 2018, [[paper]](https://arxiv.org/pdf/1806.09790.pdf)
-- Research on Vehicle Object Detection Method Based on Convolutional Neural Network, IEEE ISCID 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8695461) NoPDF
+- Research on Vehicle Object Detection Method Based on Convolutional Neural Network, IEEE ISCID 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8695461) 
 
 ## 5.2. Small object detection in aerial image <a name="5.2"></a> 
 - Clustered Object Detection in Aerial Images, arXiv 2019, [[paper]](https://arxiv.org/pdf/1904.08008.pdf)
-- Pedestrian Detection in Aerial Images Using Vanishing Point Transformation and Deep Learning, IEEE ICIP 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8451144) NoPDF
+- Pedestrian Detection in Aerial Images Using Vanishing Point Transformation and Deep Learning, IEEE ICIP 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8451144) 
 -  Small Target Detection for Search and Rescue Operations using Distributed Deep Learning and Synthetic Data Generation, arXiv 2019, [[paper]](https://arxiv.org/ftp/arxiv/papers/1904/1904.11619.pdf)
 - Differentiating Objects by Motion: Joint Detection and Tracking of Small Flying Objects, arXiv 2017, [[paper]](https://arxiv.org/pdf/1709.04666.pdf)
 - Combining deep features for object detection at various scales: finding small birds in landscape images, IPSJ CVA 2016, [[paper]](https://ipsjcva.springeropen.com/track/pdf/10.1186/s41074-016-0006-z)
@@ -115,7 +115,7 @@ If you know of a paper that addresses an Vision-based Small Object Detection pro
 ## 5.3. others <a name="5.3"></a> 
 - An Energy and GPU-Computation Efficient Backbone Network for Real-Time Object Detection, CVPR 2019, [[paper]](http://openaccess.thecvf.com/content_CVPRW_2019/papers/CEFRL/Lee_An_Energy_and_GPU-Computation_Efficient_Backbone_Network_for_Real-Time_Object_CVPRW_2019_paper.pdf)
 - Evaluation of Deep Models for Real-Time Small Object Detection, ICONIP 2017, [[paper]](https://link.springer.com/chapter/10.1007/978-3-319-70090-8_53)
-- Small-objectness sensitive detection based on shifted single shot detector, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6227-7)NoPDF
+- Small-objectness sensitive detection based on shifted single shot detector, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6227-7)
 - CNN-based small object detection and visualization with feature activation mapping, IEEE IVCNZ 2017, [[paper]](https://ieeexplore.ieee.org/abstract/document/8402455)
 - Real-Time Detecting Method of Marine Small Object with Underwater Robot Vision,  IEEE OTO 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8558804)
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,123 @@
 # SmallObjectDetectionList
-List of the Papers Addressing Vision-based Small Object Detection
+List of the Papers Addressing Vision-based Small Object Detection, links to more than 50 papers are given below.(please cite the paper if you benefit from this repository):
+
+``````````````````````````````
+### To be finished, need to change to ours when the survey is done
+K. Oksuz, B. C. Cam, S. Kalkan, E. Akbas, "Imbalance Problems in Object Detection: A Review", (under review), 2019.[[preprint]](https://arxiv.org/abs/1909.00169)
+
+BibTeX entry:
+```
+@ARTICLE{imbalance,
+       author = {Kemal Oksuz and Baris Can Cam and Sinan Kalkan and Emre Akbas},
+        title = "{Imbalance Problems in Object Detection: A Review}",
+      journal = {arXiv e-prints},
+         year = "2019",
+        month = "Aug",
+        pages = {arXiv:1909.00169},
+          ee  = {https://arxiv.org/abs/1909.00169},
+       eprint = {1909.00169} 
+}
+```
+
+``````````````````````````````
+
+## How to request addition of a paper
+If you know of a paper that addresses an Vision-based Small Object Detection problem and is not on this repository, you are welcome to request  the addition of that paper by submitting a pull request. In your pull request please briefly state which section of your paper is related to which problem.
+
+
+
+# Table of Contents
+1.[Multi-scales representation](#1)  
+>1.1 [Multiple feature maps fusion](#1.1)  
+1.2 [Connection method of different feature maps](#1.2)
+
+2.[Contextual information](#2)    
+
+3.[Super-Resolution](#3)    
+
+4.[Region-proposal](#4)    
+
+5.[Others](#5)    
+>5.1 [Traffic road object detection](#5.1)  
+5.2 [Small object detection in aerial image](#5.2)   
+5.3 [others](#5.3)  
+    
+# 1. Multi-scales representation <a name="1"></a>
+
+## 1.1. Multiple feature maps fusion <a name="1.1"></a>  
+- MDSSD: Multi-scale Deconvolutional Single Shot Detector for Small Objects, arXiv 2018, [[paper]](https://arxiv.org/pdf/1805.07009.pdf)   
+- MR-CNN: A Multi-Scale Region-Based Convolutional Neural Network for Small Traffic Sign Recognition, IEEE Acess 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8701699)
+- Improving Tiny Vehicle Detection in Complex Scenes, IEEE ICME 2018, [[paper]](https://ieeexplore.ieee.org/application/enterprise/entconfirmation.jsp?arnumber=8486507&icp=false) NoPDF
+- Small Object Detection with Multiscale Features, Int. J. Digit. Multimedia Broadcast 2018, [[paper]](https://pdfs.semanticscholar.org/942e/386250587fc789d807093cc56f0a95f9798c.pdf?_ga=2.175036386.1996274586.1568206454-1908503646.1568206454)
+- A detection method for low-pixel ratio object, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6653-6) NoPDF
+- Research on Small Size Object Detection in Complex Background, CAC 2018, [[paper]](https://www.semanticscholar.org/paper/Research-on-Small-Size-Object-Detection-in-Complex-Du-Qu/46b1f5b937e114be94d4359c7779372e09ddd122) NoPDF
+- Small Object Detection Using Deep Feature Pyramid Networks, PCM 2018, [[paper]](https://link.springer.com/chapter/10.1007/978-3-030-00764-5_51) NoPDF 
+- Multiple receptive fields and small-object-focusing weaklysupervised segmentation network for fast object detection, arXiv 2019, [[paper]](https://arxiv.org/ftp/arxiv/papers/1904/1904.12619.pdf)
+- A Block Object Detection Method Based on Feature Fusion Networks for Autonomous Vehicles, Complexity 2019, [[paper]](http://downloads.hindawi.com/journals/complexity/2019/4042624.pdf)
+- Small Object Sensitive Segmentation of Urban Street Scene with Spatial Adjacency Between Object Classes, IEEE TIP 2019, [[paper]](https://cse.sc.edu/~songwang/document/tip19b.pdf)
+## 1.2. Connection method of different feature maps <a name="1.2"></a>  
+- Detecting Small Objects Using a Channel-Aware Deconvolutional Network, IEEE TCSVT 2019, [[paper]](https://ieeexplore.ieee.org/document/8669953) NoPDF
+- A unified multi-scale deep convolutional neural network for fast object detection, ECCV 2016, [[paper]](http://www.cvlibs.net/projects/autonomous_vision_survey/literature/Cai2016ECCV.pdf)
+
+# 2. Contextual Information <a name="2"></a>
+- Inside-Outside Net: Detecting Objects in Context with Skip Pooling and Recurrent Neural Networks, CVPR 2016, [[paper]](http://openaccess.thecvf.com/content_cvpr_2016/papers/Bell_Inside-Outside_Net_Detecting_CVPR_2016_paper.pdf) 
+- VSSA-NET: Vertical Spatial Sequence Attention Network for Traffic Sign Detection, IEEE TIP 2019, [[paper]](https://arxiv.org/pdf/1905.01583.pdf)
+- R-CNN for Small Object Detection, ACCV 2016, [[paper]](https://merl.com/publications/docs/TR2016-144.pdf)
+- Detecting The Objects on The Road Using Modular Lightweight Network, arXiv 2019, [[paper]](https://arxiv.org/ftp/arxiv/papers/1811/1811.06641.pdf)
+- Feature-fused ssd: fast detection for small objects, ICGIP 2017, [[paper]](https://arxiv.org/ftp/arxiv/papers/1709/1709.05054.pdf)
+- Spatial Memory for Context Reasoning in Object Detection, ICCV 2017, [[paper]](http://openaccess.thecvf.com/content_ICCV_2017/papers/Chen_Spatial_Memory_for_ICCV_2017_paper.pdf)
+- ContextAware Single-Shot Detector, WACV 2018, [[paper]](https://arxiv.org/pdf/1707.08682.pdf)
+- Detecting Traffic Lights by Single Shot Detection, ITSC 2018, [[paper]](https://arxiv.org/pdf/1805.02523.pdf)
+- SCAN: Semantic Context Aware Network for Accurate Small Object Detection, IJCIS 2018, [[paper]](https://www.atlantis-press.com/journals/ijcis/25894607/view)
+- SINet: A ScaleInsensitive Convolutional Neural Network for Fast Vehicle Detection, IEEE ITS 2019, [[paper]](https://arxiv.org/pdf/1804.00433.pdf)
+- Robust Obstacle Detection and Recognition for Driver Assistance Systems, IEEE ITS 2019, [[paper]](https://www.researchgate.net/profile/Jiaxu_Leng2/publication/332438373_Robust_Obstacle_Detection_and_Recognition_for_Driver_Assistance_Systems/links/5cbeb092a6fdcc1d49a87438/Robust-Obstacle-Detection-and-Recognition-for-Driver-Assistance-Systems.pdf)
+-  Object Detection in Aerial Images Using Feature Fusion Deep Networks, IEEE Acess 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8661761)
+- Small Object Detection in Unmanned Aerial Vehicle Images Using Feature Fusion and Scaling-Based Single Shot Detector with Spatial Context Analysis, IEEE TCSVT 2019, [[paper]](https://ieeexplore.ieee.org/abstract/document/8672115) NoPDF
+
+# 3. Super-Resolution <a name="3"></a>
+- JCS-Net: Joint Classification and SuperResolution Network for Small-scale Pedestrian Detection in Surveillance Images, IEEE TIFS 2019, [[paper]](https://ieeexplore.ieee.org/abstract/document/8714071) NoPDF
+- Accurate image superresolution using very deep convolutional networks, CVPR 2016, [[paper]](https://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Kim_Accurate_Image_Super-Resolution_CVPR_2016_paper.pdf)
+- Finding tiny faces in the wild with generative adversarial network, CVPR 2018, [[paper]](http://openaccess.thecvf.com/content_cvpr_2018/papers/Bai_Finding_Tiny_Faces_CVPR_2018_paper.pdf)
+- Multi-branch fully convolutional network for face detection, arXiv 2017, [[paper]](https://arxiv.org/pdf/1707.06330.pdf)
+- SOD-MTGAN: Small Object Detection via Multi-Task Generative Adversarial Network, ECCV 2018, [[paper]](http://openaccess.thecvf.com/content_ECCV_2018/papers/Yongqiang_Zhang_SOD-MTGAN_Small_Object_ECCV_2018_paper.pdf)
+-  Improving Small Object Detection, ACPR 2017, [[paper]](http://cdn.iiit.ac.in/cdn/cvit.iiit.ac.in/images/ConferencePapers/2017/Improving-SmallObject-Detection.pdf)
+- Perceptual Generative Adversarial Networks for Small Object Detection, CVPR 2017, [[paper]](http://openaccess.thecvf.com/content_cvpr_2017/papers/Li_Perceptual_Generative_Adversarial_CVPR_2017_paper.pdf)
+
+# 4. Region-Proposal <a name="4"></a>
+- STDnet: A ConvNet for Small Target Detection, BMVC 2018, [[paper]](http://bmvc2018.org/contents/papers/0897.pdf)
+- AttentionMask: Attentive, Efficient Object Proposal Generation Focusing on Small Objects, ACCV 2018, [[paper]](https://arxiv.org/pdf/1811.08728.pdf)
+- A PSO and BFO-Based Learning Strategy Applied to Faster R-CNN for Object Detection in Autonomous Driving, IEEE Access 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8633817)
+- Improving Small Object Proposals for Company Logo Detection, ICMR 2017, [[paper]](https://arxiv.org/pdf/1704.08881.pdf)
+- Augmentation for small object detection, arXiv 2019, [[paper]](https://arxiv.org/pdf/1902.07296)
+- Detecting Small Signs from Large Images, IEEE IRI 2017, [[paper]](https://arxiv.org/pdf/1706.08574.pdf)
+- Cascade Mask Generation Framework for Fast Small Object Detection, IEEE ICME 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8486561) NoPDF
+- Cascaded CNN Method for Far Object Detection in Outdoor Surveillance, IEEE SITIS 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8706233) NoPDF
+- SSD-MSN: An Improved Multi-scale Object Detection Network Based on SSD, IEEE Access 2019, [[paper]](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8736726)
+
+# 5. Others <a name="5"></a>
+
+## 5.1. Traffic road object detection <a name="5.1"></a> 
+- Knowledge-based recurrent attentive neural network for small object detection, arXiv 2018, [[paper]](https://arxiv.org/pdf/1803.05263.pdf)
+- Efficient convNets for fast traffic sign recognition, IET ITS 2019, [[paper]](https://digital-library.theiet.org/content/journals/10.1049/iet-its.2018.5489) NoPDF
+- Real-time small traffic sign detection with revised faster-RCNN, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6428-0) NoPDF
+- Small-scale Pedestrian Detection Based on Topological Line Localization and Temporal Feature Aggregation, ECCV 2018, [[paper]](http://openaccess.thecvf.com/content_ECCV_2018/papers/Tao_Song_Small-scale_Pedestrian_Detection_ECCV_2018_paper.pdf)
+- An Efficient Color Space for Deep-Learning Based Traffic Light Recognition, J Adv Transport 2018, [[paper]](http://downloads.hindawi.com/journals/jat/2018/2365414.pdf)
+- CFENet: An Accurate and Efficient Single-Shot Object Detector for Autonomous Driving, arXiv 2018, [[paper]](https://arxiv.org/pdf/1806.09790.pdf)
+- Research on Vehicle Object Detection Method Based on Convolutional Neural Network, IEEE ISCID 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8695461) NoPDF
+
+## 5.2. Small object detection in aerial image <a name="5.2"></a> 
+- Clustered Object Detection in Aerial Images, arXiv 2019, [[paper]](https://arxiv.org/pdf/1904.08008.pdf)
+- Pedestrian Detection in Aerial Images Using Vanishing Point Transformation and Deep Learning, IEEE ICIP 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8451144) NoPDF
+-  Small Target Detection for Search and Rescue Operations using Distributed Deep Learning and Synthetic Data Generation, arXiv 2019, [[paper]](https://arxiv.org/ftp/arxiv/papers/1904/1904.11619.pdf)
+- Differentiating Objects by Motion: Joint Detection and Tracking of Small Flying Objects, arXiv 2017, [[paper]](https://arxiv.org/pdf/1709.04666.pdf)
+- Combining deep features for object detection at various scales: finding small birds in landscape images, IPSJ CVA 2016, [[paper]](https://ipsjcva.springeropen.com/track/pdf/10.1186/s41074-016-0006-z)
+
+## 5.3. others <a name="5.3"></a> 
+- An Energy and GPU-Computation Efficient Backbone Network for Real-Time Object Detection, CVPR 2019, [[paper]](http://openaccess.thecvf.com/content_CVPRW_2019/papers/CEFRL/Lee_An_Energy_and_GPU-Computation_Efficient_Backbone_Network_for_Real-Time_Object_CVPRW_2019_paper.pdf)
+- Evaluation of Deep Models for Real-Time Small Object Detection, ICONIP 2017, [[paper]](https://link.springer.com/chapter/10.1007/978-3-319-70090-8_53)
+- Small-objectness sensitive detection based on shifted single shot detector, Multimed Tools Appl 2019, [[paper]](https://link.springer.com/article/10.1007/s11042-018-6227-7)NoPDF
+- CNN-based small object detection and visualization with feature activation mapping, IEEE IVCNZ 2017, [[paper]](https://ieeexplore.ieee.org/abstract/document/8402455)
+- Real-Time Detecting Method of Marine Small Object with Underwater Robot Vision,  IEEE OTO 2018, [[paper]](https://ieeexplore.ieee.org/abstract/document/8558804)
+
+# Contact 
+Please contact Zida Song(szd16688@qq.com) for your questions about this webpage.


### PR DESCRIPTION
58 paper for Vision-based Small Object Detection has been linked in,  mainly from "chapter 3: Small object Detection Networks" in our paper. The citation of our paper need to be updated when we finished it.